### PR TITLE
Adjust timeout handling

### DIFF
--- a/.github/workflows/build-vim.yaml
+++ b/.github/workflows/build-vim.yaml
@@ -339,17 +339,21 @@ jobs:
 
         echo %COL_GREEN%Wait for vim tests to finish.%COL_RESET%
         cd ..\src2\testdir
-        :: Wait about 5 minutes.
-        for /L %%i in (1,1,300) do (
+        :: Wait about 10 minutes.
+        for /L %%i in (1,1,600) do (
           if exist done.txt goto exitloop
           ping -n 2 localhost > nul
         )
-        echo %COL_RED%Timed out.%COL_RESET%
+        set timeout=1
         :exitloop
 
         echo %COL_GREEN%Test results of vim:%COL_RESET%
         if exist messages type messages
         nmake -nologo -f Make_dos.mak report VIMPROG=..\..\src\vim || exit 1
+        if "%timeout%"=="1" (
+          echo %COL_RED%Timed out.%COL_RESET%
+          exit 1
+        )
 
     - name: Package
       if: steps.check.outputs.skip == 'no' || github.event_name == 'pull_request'


### PR DESCRIPTION
* Extends the timeout from 5 min to 10 min.
  (Sometimes, it takes longer time.)
* Show the timeout message after showing the log.
* Return 1 when it timed out.