### PR TITLE
doc: Change RubyInstaller2 to RubyInstaller

### DIFF
--- a/.github/workflows/build-vim.yaml
+++ b/.github/workflows/build-vim.yaml
@@ -481,7 +481,7 @@ jobs:
           * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) ${{ env.LUA_VER_DOT }}
           * [Strawberry Perl](https://strawberryperl.com/) ${{ env.PERL_VER_DOT }}
           * [Python3](https://www.python.org/downloads/) ${{ env.PYTHON3_VER_DOT }}
-          * [RubyInstaller2](https://rubyinstaller.org/downloads/) ${{ env.RUBY_VER_DOT }}
+          * [RubyInstaller](https://rubyinstaller.org/downloads/) ${{ env.RUBY_VER_DOT }}
         draft: false
         prerelease: false
         files: |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The following interfaces are enabled:
 * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.4 (included)
 * [Strawberry Perl](https://strawberryperl.com/) 5.32
 * [Python3](https://www.python.org/downloads/) 3.9
-* [RubyInstaller2](https://rubyinstaller.org/downloads/) 3.0
+* [RubyInstaller](https://rubyinstaller.org/downloads/) 3.0
 
 Perl, Python3 and Ruby are not included in this package. If you want use them, install the official binaries from the above sites.
 


### PR DESCRIPTION
"RubyInstaller2 3.0" is a bit confusing.

[The official site](https://rubyinstaller.org/) uses the name "RubyInstaller".
The name "RubyInstaller2" seems to be used only in [the GitHub repository](https://github.com/oneclick/rubyinstaller2).
So, the name "RubyInstaller2" seems to be an internal name.