### PR TITLE
doc: Change Python3 to Python

### DIFF
--- a/.github/workflows/build-vim.yaml
+++ b/.github/workflows/build-vim.yaml
@@ -480,7 +480,7 @@ jobs:
 
           * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) ${{ env.LUA_VER_DOT }}
           * [Strawberry Perl](https://strawberryperl.com/) ${{ env.PERL_VER_DOT }}
-          * [Python3](https://www.python.org/downloads/) ${{ env.PYTHON3_VER_DOT }}
+          * [Python](https://www.python.org/downloads/) ${{ env.PYTHON3_VER_DOT }}
           * [RubyInstaller](https://rubyinstaller.org/downloads/) ${{ env.RUBY_VER_DOT }}
         draft: false
         prerelease: false

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ The following interfaces are enabled:
 
 * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.4 (included)
 * [Strawberry Perl](https://strawberryperl.com/) 5.32
-* [Python3](https://www.python.org/downloads/) 3.9
+* [Python](https://www.python.org/downloads/) 3.9
 * [RubyInstaller](https://rubyinstaller.org/downloads/) 3.0
 
-Perl, Python3 and Ruby are not included in this package. If you want use them, install the official binaries from the above sites.
+Perl, Python and Ruby are not included in this package. If you want use them, install the official binaries from the above sites.
 
 ## Plugins
 


### PR DESCRIPTION
Python 2 ended nearly two years ago.
Nowadays "Python" means "Python 3".