### PR TITLE
Remove workaround for suppressing the progress of link

### DIFF
--- a/.github/workflows/build-vim.yaml
+++ b/.github/workflows/build-vim.yaml
@@ -311,10 +311,8 @@ jobs:
       run: |
         call "%VCVARSALL%" ${{ matrix.vcarch }}
         cd vim\src
-        rem Suppress progress animation
-        sed -e "s/@<<$/@<< | sed -e 's#.*\\\\r.*##'/" Make_mvc.mak > Make_mvc2.mak
         rem Build gvim/vim with VIMDLL
-        nmake -nologo -f Make_mvc2.mak ^
+        nmake -nologo -f Make_mvc.mak ^
           GUI=yes IME=yes ICONV=yes VIMDLL=yes ^
           DYNAMIC_LUA=yes LUA=%LUA_DIR% ^
           DYNAMIC_PERL=yes PERL=%PERL_DIR% ^


### PR DESCRIPTION
This was fixed by changing the link option `/LTCG:STATUS` to `/LTCG`.