### PR TITLE
CI: Don't use fail-fast

### DIFF
--- a/.github/workflows/build-vim.yaml
+++ b/.github/workflows/build-vim.yaml
@@ -64,6 +64,7 @@ jobs:
     runs-on: windows-latest
 
     strategy:
+      fail-fast: false
       matrix:
         arch: [x64, x86]
         include:


### PR DESCRIPTION
Now GHA supports rerunning only failed jobs.