### PR TITLE
CI: Use jobs' outputs

### DIFF
--- a/.github/workflows/build-vim.yaml
+++ b/.github/workflows/build-vim.yaml
@@ -87,6 +87,9 @@ jobs:
             cygreg: registry32
             pyreg: "-32"
 
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+
     steps:
     - name: Initalize
       id: init
@@ -443,6 +446,7 @@ jobs:
         7z a -mx=9 artifacts\%BASENAME%-pdb.7z *.pdb
 
     - name: Upload Artifact
+      if: steps.check.outputs.skip == 'no'
       uses: actions/upload-artifact@v3
       with:
         name: vim-kt-win${{ matrix.bits }}
@@ -451,7 +455,7 @@ jobs:
   release:
     runs-on: windows-latest
     needs: [build]
-    if: github.event_name != 'pull_request'
+    if: (github.event_name != 'pull_request') && (needs.build.outputs.skip == 'no')
 
     steps:
     - name: Initalize
@@ -497,22 +501,19 @@ jobs:
       run: |
         if git diff --quiet HEAD vimver.txt; then
           echo ${COL_YELLOW}No updates.${COL_RESET}
-          echo "::set-output name=skip::yes"
-        else
-          cp vim-kt-win64/latestrev.txt vimrev.txt
-          git config --local user.name "$USER_NAME"
-          git config --local user.email "$USER_EMAIL"
-          git commit -a \
-            -m "Update Vim to ${{ steps.changelog.outputs.tag }}" \
-            -m "$(cat vim-kt-win64/changelog.txt)"
-          git tag "${{ steps.changelog.outputs.tag }}"
-          git push origin HEAD --tags
-          echo "::set-output name=skip::no"
+          exit 1  # This should not happen.
         fi
+        cp vim-kt-win64/latestrev.txt vimrev.txt
+        git config --local user.name "$USER_NAME"
+        git config --local user.email "$USER_EMAIL"
+        git commit -a \
+          -m "Update Vim to ${{ steps.changelog.outputs.tag }}" \
+          -m "$(cat vim-kt-win64/changelog.txt)"
+        git tag "${{ steps.changelog.outputs.tag }}"
+        git push origin HEAD --tags
 
     - name: Create Release
       uses: softprops/action-gh-release@9993ae85344fa542b3edb2533f97011277698cf6
-      if: steps.commit.outputs.skip == 'no'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
Don't use artifacts when skipping.