### PR TITLE
CI: Enable 8.3 names for testing

### DIFF
--- a/.github/workflows/build-vim.yaml
+++ b/.github/workflows/build-vim.yaml
@@ -112,6 +112,11 @@ jobs:
         #python3_dir=$(cat "/proc/${{ matrix.cygreg }}/HKEY_LOCAL_MACHINE/SOFTWARE/Python/PythonCore/${PYTHON3_VER_DOT}${{ matrix.pyreg }}/InstallPath/@")
         #echo "PYTHON3_DIR=$python3_dir" >> $GITHUB_ENV
 
+    - name: Enable 8.3 names for testing
+      shell: cmd
+      run: |
+        fsutil 8dot3name set D: 0
+
     - uses: msys2/setup-msys2@v2
       with:
         update: true


### PR DESCRIPTION
Works around Test_ColonEight_MultiByte() errors.

> command line..script D:/a/vim-kt/vim-kt/vim/src/testdir/runtest.vim[607]..function RunTheTest[57]..Test_ColonEight_MultiByte line 11: Expected not equal to 'Xtest/日��本��語��の��フ��ァ��イ��ル��.txt'
> command line..script D:/a/vim-kt/vim-kt/vim/src/testdir/runtest.vim[607]..function RunTheTest[57]..Test_ColonEight_MultiByte line 12: Pattern '\~' does not match 'Xtest/日��本��語��の��フ��ァ��イ��ル��.txt'