### PR TITLE
CI: Adjust GETTEXT_PATH

### DIFF
--- a/.github/workflows/build-vim.yaml
+++ b/.github/workflows/build-vim.yaml
@@ -14,7 +14,7 @@ permissions:
 env:
   VIMREPO: https://github.com/vim/vim
   MQREPO: http://hg.pf.osdn.net/view/k/k_/k_takata/vim-ktakata-mq
-  MSYSBIN: D:\msys64\usr\bin
+  GETTEXT_PATH: D:\msys64\usr\bin
 
   # Account for committing
   USER_NAME: "vim-kt CI"
@@ -377,7 +377,7 @@ jobs:
           exit 1
         )
         cd po
-        nmake -nologo -f Make_mvc.mak "GETTEXT_PATH=%MSYSBIN%" || exit 1
+        nmake -nologo -f Make_mvc.mak || exit 1
         nmake -nologo -f Make_mvc.mak install-all
 
     - name: Check version


### PR DESCRIPTION
Set GETTEXT_PATH not only when building po files but also running normal tests.