### PR TITLE
Fix release job conditions

### DIFF
--- a/.github/workflows/build-vim.yaml
+++ b/.github/workflows/build-vim.yaml
@@ -100,7 +100,7 @@ jobs:
             sys: mingw32
 
     outputs:
-      skip: ${{ steps.check.outputs.skip }}
+      skip_release: ${{ steps.check.outputs.skip_release }}
 
     steps:
     - name: Initalize
@@ -218,11 +218,19 @@ jobs:
           if [ "${{ github.event_name }}" = 'pull_request' ]; then
             # Don't skip on pull_request even if there are no updates.
             echo "skip=no" >> $GITHUB_OUTPUT
+            echo "skip_release=yes" >> $GITHUB_OUTPUT
           else
             echo "skip=yes" >> $GITHUB_OUTPUT
+            echo "skip_release=yes" >> $GITHUB_OUTPUT
           fi
         else
-          echo "skip=no" >> $GITHUB_OUTPUT
+          if [ "${{ github.ref_name }}" = 'master' ]; then
+            echo "skip=no" >> $GITHUB_OUTPUT
+            echo "skip_release=no" >> $GITHUB_OUTPUT
+          else
+            echo "skip=no" >> $GITHUB_OUTPUT
+            echo "skip_release=yes" >> $GITHUB_OUTPUT
+          fi
         fi
 
     - name: Create a list of download URLs
@@ -485,7 +493,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [build]
-    if: (github.event_name != 'pull_request') && (needs.build.outputs.skip == 'no')
+    if: needs.build.outputs.skip_release == 'no'
 
     permissions:
       contents: write # to create release


### PR DESCRIPTION
Run the release job only on a push to the master branch or a scheduled workflow.
Don't run on a push to other branches.