### PR TITLE
CI,package: Revert Perl to 5.32

### DIFF
--- a/.github/workflows/build-vim.yaml
+++ b/.github/workflows/build-vim.yaml
@@ -35,20 +35,23 @@ env:
 
   # Interfaces
   # Lua
+  LUA_VER_DOT: '5.4'
   LUA_RELEASE: 5.4.2
   LUA_URL: https://downloads.sourceforge.net/luabinaries/lua-%LUA_RELEASE%_Win%BITS%_dllw6_lib.zip
   LUA_DIR: D:\Lua
   # Perl
-  PERL_RELEASE_32: 5.32.1.1
-  PERL_URL_32: https://strawberryperl.com/download/%PERL_RELEASE%/strawberry-perl-%PERL_RELEASE%-%BITS%bit-portable.zip
-  PERL_RELEASE_64: 5.38.2.2
-  PERL_URL_64: https://github.com/StrawberryPerl/Perl-Dist-Strawberry/releases/download/SP_%PERL_RELEASE_NODOT%_%BITS%bit/strawberry-perl-%PERL_RELEASE%-%BITS%bit-portable.zip
+  PERL_VER_DOT: '5.32'
+  PERL_RELEASE: 5.32.1.1
+  PERL_URL: https://strawberryperl.com/download/%PERL_RELEASE%/strawberry-perl-%PERL_RELEASE%-%BITS%bit-portable.zip
+  #PERL_URL: https://github.com/StrawberryPerl/Perl-Dist-Strawberry/releases/download/SP_%PERL_RELEASE_NODOT%_%BITS%bit/strawberry-perl-%PERL_RELEASE%-%BITS%bit-portable.zip
   PERL_DIR: D:\Strawberry\perl
   # Python 3
+  PYTHON3_VER_DOT: '3.12'
   PYTHON3_RELEASE: 3.12.0
   PYTHON3_URL: https://www.python.org/ftp/python/%PYTHON3_RELEASE%/python-%PYTHON3_RELEASE%%PYARCH%.exe
   PYTHON3_DIR: D:\python3
   # Ruby
+  RUBY_VER_DOT: '3.2'
   RUBY_API_VER_LONG: 3.2.0
   RUBY_RELEASE: 3.2.2-1
   RUBY_SRC_URL: https://github.com/ruby/ruby/archive/%RUBY_BRANCH%.zip
@@ -114,31 +117,20 @@ jobs:
         git config --global core.autocrlf input
 
         # Lua
-        lua_ver_dot=${LUA_RELEASE%.*}
-        echo "LUA_VER=${lua_ver_dot//./}" >> $GITHUB_ENV
-        echo "LUA_VER_DOT=${lua_ver_dot}" >> $GITHUB_ENV
+        echo "LUA_VER=${LUA_VER_DOT//./}" >> $GITHUB_ENV
 
         # Perl
-        perl_release=${PERL_RELEASE_${{ matrix.bits }}}
-        perl_ver_dot=${perl_release%.*.*}
-        echo "PERL_VER=${perl_ver_dot//./}" >> $GITHUB_ENV
-        echo "PERL_VER_DOT=${perl_ver_dot}" >> $GITHUB_ENV
-        echo "PERL_RELEASE=${perl_release}" >> $GITHUB_ENV
-        echo "PERL_RELEASE_NODOT=${perl_release//./}" >> $GITHUB_ENV
-        echo "PERL_URL=${PERL_URL_${{ matrix.bits }}}" >> $GITHUB_ENV
+        echo "PERL_VER=${PERL_VER_DOT//./}" >> $GITHUB_ENV
+        echo "PERL_RELEASE_NODOT=${PERL_RELEASE//./}" >> $GITHUB_ENV
 
         # Python 3
-        python3_ver_dot=${PYTHON3_RELEASE%.*}
-        echo "PYTHON3_VER=${python3_ver_dot//./}" >> $GITHUB_ENV
-        echo "PYTHON3_VER_DOT=${python3_ver_dot}" >> $GITHUB_ENV
+        echo "PYTHON3_VER=${PYTHON3_VER_DOT//./}" >> $GITHUB_ENV
         #python3_dir=$(cat "/proc/${{ matrix.cygreg }}/HKEY_LOCAL_MACHINE/SOFTWARE/Python/PythonCore/${PYTHON3_VER_DOT}${{ matrix.pyreg }}/InstallPath/@")
         #echo "PYTHON3_DIR=$python3_dir" >> $GITHUB_ENV
 
         # Ruby
-        ruby_ver_dot=${RUBY_RELEASE%.*}
-        echo "RUBY_VER=${ruby_ver_dot//./}" >> $GITHUB_ENV
-        echo "RUBY_VER_DOT=${ruby_ver_dot}" >> $GITHUB_ENV
-        echo "RUBY_BRANCH=ruby_${ruby_ver_dot//./_}" >> $GITHUB_ENV
+        echo "RUBY_VER=${RUBY_VER_DOT//./}" >> $GITHUB_ENV
+        echo "RUBY_BRANCH=ruby_${RUBY_VER_DOT//./_}" >> $GITHUB_ENV
 
 #    - name: Enable 8.3 names for testing
 #      shell: cmd
@@ -578,9 +570,7 @@ jobs:
         ### Compiled with:
 
         * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) ${{ env.LUA_VER_DOT }}
-        * [Strawberry Perl](https://strawberryperl.com/):
-          - 32-bit: ${{ env.PERL_VER_DOT_32 }}
-          - 64-bit: ${{ env.PERL_VER_DOT_64 }}
+        * [Strawberry Perl](https://strawberryperl.com/) ${{ env.PERL_VER_DOT }}
         * [Python](https://www.python.org/downloads/) ${{ env.PYTHON3_VER_DOT }}
         * [RubyInstaller](https://rubyinstaller.org/downloads/) ${{ env.RUBY_VER_DOT }}
         EOF


### PR DESCRIPTION
Perl 5.38 shows the following warning:
```
Locale 'Japanese_Japan.932' is unsupported, and may crash the interpreter.
```
Revert to 5.32.

Also, restore {LANG}_VER_DOT definitions.
They are used in the release job.