### PR TITLE
Reduce git commit log

### DIFF
--- a/.github/workflows/build-vim.yaml
+++ b/.github/workflows/build-vim.yaml
@@ -612,7 +612,7 @@ jobs:
         git config --local user.email "$USER_EMAIL"
         git commit -a \
           -m "Update Vim to ${{ steps.changelog.outputs.tag }}" \
-          -m "$(cat vim-kt-win64/changelog.txt)"
+          -m "$(head -n 50 vim-kt-win64/changelog.txt)"
         git tag "${{ steps.changelog.outputs.tag }}"
         git push origin HEAD --tags
 


### PR DESCRIPTION
Work around the following error:
https://github.com/k-takata/vim-kt/actions/runs/25486056553/job/74784546747#logs
> /home/runner/work/_temp/a0cde2fb-e732-45de-bf4f-0f6d73d6f772.sh: line 11: /usr/bin/git: Argument list too long
> Error: Process completed with exit code 126.
