### PR TITLE
Use deploy key when creating a release

### DIFF
--- a/.github/workflows/build-vim.yaml
+++ b/.github/workflows/build-vim.yaml
@@ -573,6 +573,8 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       if: github.event_name != 'workflow_dispatch'
+      with:
+        ssh-key: ${{ secrets.VIM_KT_DEPLOY_KEY }}
     - uses: actions/checkout@v6
       if: github.event_name == 'workflow_dispatch'
       with:


### PR DESCRIPTION
Now branch protection is enabled, and it prevents pushing to the master branch from the release job.
Use deploy key to bypass the branch protection rules when creating a release.