### PR TITLE
Use deploy key to create a release

### DIFF
--- a/.github/workflows/build-vim.yaml
+++ b/.github/workflows/build-vim.yaml
@@ -676,6 +676,7 @@ jobs:
         body_path: changelog.md
         draft: false
         prerelease: false
+        token: ${{ secrets.VIM_KT_DEPLOY_KEY }}
         files: |
           ./vim-kt-win32/vim-kt-*-*-win32.zip
           ./vim-kt-win32/vim-kt-*-*-win32.7z

--- a/.github/workflows/update-release-list.yaml
+++ b/.github/workflows/update-release-list.yaml
@@ -1,12 +1,12 @@
 name: Update Release List
 
 on:
-  #release:
-  #  types: [published]
-  workflow_run:
-    workflows: ["Build Vim"]
-    branches: [master]
-    types: [completed]
+  release:
+    types: [published]
+  #workflow_run:
+  #  workflows: ["Build Vim"]
+  #  branches: [master]
+  #  types: [completed]
 
 permissions:
   contents: write # to update wiki
@@ -25,7 +25,7 @@ env:
 jobs:
   update:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    #if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
If the default GITHUB_TOKEN is used to create a release, it will not trigger a workflow except `on.workflow_run`.
https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow

However, `on.workflow_run` is triggered even if the release job has been canceled or failed.

Use deploy key to use the `on.release` trigger.